### PR TITLE
Revised based on decisions of the PGB

### DIFF
--- a/GOVERNANCE-NTAC.md
+++ b/GOVERNANCE-NTAC.md
@@ -18,7 +18,7 @@ The NTAC is responsible for transforming the business requirements of NIEM into 
 
 The NTAC must at all times have a chair or two co-chairs. The NTAC chair or co-chairs are appointed by the PGB and serve staggered two-year terms, renewable by the PGB.
 
-We anticipate the PGB will delegate the appointment of other NTAC voting members to the co-chairs.  Nominees for NTAC voting members can be submitted by any individual to the NTAC chairs. Voting members are appointed and serve at the discretion of the NTAC chairs, ordinarily for a 2 year renewable term.
+The PGB delegates the authority to approve other NTAC voting members to the co-chairs in accordance with [Open Project Rules](https://www.oasis-open.org/policies-guidelines/open-projects-process/) and with notification to the PGB.  Nominees for NTAC voting members can be submitted by any individual to the NTAC chairs. Voting members serve ordinarily for a 2 year renewable term.
 
 NTAC observers may be admitted to any meeting at the discretion of the NTAC chairs.
 
@@ -26,7 +26,7 @@ NTAC observers may be admitted to any meeting at the discretion of the NTAC chai
 
 For most decisions, the NTAC operates by [lazy consensus](https://community.apache.org/committers/lazyConsensus.html). The following decisions are made by agreement of the co-chairs:
 
-* Appointment of the NTAC voting member on the PGB [(according to Open Projects Rule 5.1)](https://www.oasis-open.org/policies-guidelines/open-projects-process/#project-governing-board-and-sponsors-composition).
+* Appointment of the NTAC voting member as an Expert Voting on the PGB [(according to Open Projects Rule 5.1)](https://www.oasis-open.org/policies-guidelines/open-projects-process/#project-governing-board-and-sponsors-composition) on a rotating basis.
 
 The NTAC may, at its own discretion, delegate authority on minor technical decisions to Maintainers in the community, including but not limited to:
 
@@ -37,6 +37,7 @@ The NTAC may, at its own discretion, delegate authority on minor technical decis
 
 Decisions on the following items must be made based on a [Simple Majority Vote](https://www.oasis-open.org/policies-guidelines/oasis-defined-terms-2018-05-22#dSimpleMajority)
 
+- Creation of a new repository and appointment of one or more Maintainers to the repository. 
 - Tagging / releasing of a new *major version* of a project
 - Recommending work to the PGB for promotion to the standards track
 


### PR DESCRIPTION
Revised based on the following decisions from the last PGB meeting:

•	NIEMOpen PGB Expert Voting Members from TSCs may be appointed by the TSCs on a rotating basis.
•	The PGB delegate TSCs the authority to approve TSC memberships in accordance with Open Project Rules with notification to the PGB. 
•	That the PGB delegate to each TSC the authority to request the creation of new repos, and the responsibility that each repo have one or more maintainers
